### PR TITLE
feat: 视频发布&发布点击修复

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: RedBookSkills
 description: |
-  将图文内容自动发布到小红书（XHS）。
-  支持两类任务：发布图文、仅启动测试浏览器（不发布）。
+  将图文/视频内容自动发布到小红书（XHS）。
+  支持三类任务：发布图文、发布视频、仅启动测试浏览器（不发布）。
 metadata:
   trigger: 发布内容到小红书
   source: Angiin/Post-to-xhs
@@ -15,18 +15,20 @@ metadata:
 ## 输入判断
 
 优先按以下顺序判断：
-1. 用户明确要求“测试浏览器 / 启动浏览器 / 检查登录 / 只打开不发布”：进入测试浏览器流程。
-2. 用户已提供 `标题 + 正文 + 图片(本地路径或URL)`：直接进入发布流程。
-3. 用户只提供网页 URL：先提取网页内容与图片，再给出可发布草稿，等待用户确认。
-4. 信息不全：先补齐缺失信息，不要直接发布。
+1. 用户明确要求"测试浏览器 / 启动浏览器 / 检查登录 / 只打开不发布"：进入测试浏览器流程。
+2. 用户已提供 `标题 + 正文 + 视频(本地路径或URL)`：直接进入视频发布流程。
+3. 用户已提供 `标题 + 正文 + 图片(本地路径或URL)`：直接进入图文发布流程。
+4. 用户只提供网页 URL：先提取网页内容与图片/视频，再给出可发布草稿，等待用户确认。
+5. 信息不全：先补齐缺失信息，不要直接发布。
 
 ## 必做约束
 
-- 发布前必须让用户确认最终标题、正文和图片。
-- 没有图片时不得发布（小红书发图文必须有图片）。
+- 发布前必须让用户确认最终标题、正文和图片/视频。
+- 图文发布时，没有图片不得发布（小红书发图文必须有图片）。
+- 视频发布时，没有视频不得发布。图片和视频不可混合使用（二选一）。
 - 默认使用无头模式；若检测到未登录，切换有窗口模式登录。
 - 标题长度不超过 38（中文/中文标点按 2，英文数字按 1）。
-- 用户要求“仅测试浏览器”时，不得触发发布命令。
+- 用户要求"仅测试浏览器"时，不得触发发布命令。
 - 如果使用文件路径，必定使用绝对路径，禁止使用相对路径
 
 ## 测试浏览器流程（不发布）
@@ -36,11 +38,18 @@ metadata:
 3. 可选：执行登录状态检查并回传结果。
 4. 结束后如用户要求，关闭测试浏览器实例。
 
-## 发布流程
+## 图文发布流程
 
 1. 准备输入（标题、正文、图片 URL 或本地图片）。
 2. 如需文件输入，先写入 `title.txt`、`content.txt`。
 3. 执行发布命令（默认无头）。
+4. 回传执行结果（成功/失败 + 关键信息）。
+
+## 视频发布流程
+
+1. 准备输入（标题、正文、视频文件路径或 URL）。
+2. 如需文件输入，先写入 `title.txt`、`content.txt`。
+3. 执行视频发布命令（默认无头）。视频上传后需等待处理完成。
 4. 回传执行结果（成功/失败 + 关键信息）。
 
 ## 常用命令
@@ -121,6 +130,38 @@ python scripts/publish_pipeline.py --headless \
 python scripts/publish_pipeline.py --port 9223 --title-file title.txt \
   --content-file content.txt \
   --images "./images/pic1.jpg" "./images/pic2.jpg"
+```
+
+### 3.5) 视频发布（本地视频文件）
+
+```bash
+python scripts/publish_pipeline.py --headless \
+  --port 9223 \
+  --title-file title.txt \
+  --content-file content.txt \
+  --video "C:/videos/my_video.mp4"
+```
+
+```bash
+python scripts/publish_pipeline.py --port 9223 --title-file title.txt \
+  --content-file content.txt \
+  --video "C:/videos/my_video.mp4"
+```
+
+### 3.6) 视频发布（视频 URL）
+
+```bash
+python scripts/publish_pipeline.py --headless \
+  --port 9223 \
+  --title-file title.txt \
+  --content-file content.txt \
+  --video-url "https://example.com/video.mp4"
+```
+
+```bash
+python scripts/publish_pipeline.py --port 9223 --title-file title.txt \
+  --content-file content.txt \
+  --video-url "https://example.com/video.mp4"
 ```
 
 ### 4) 多账号发布 /切换


### PR DESCRIPTION
一、视频发布功能的支持，修改了以下 4 个文件：
1. scripts/cdp_publish.py
新增 "video_tab" / "video_tab_text" 选择器（对应"上传视频" tab）
新增 VIDEO_PROCESS_TIMEOUT (120s) 和 VIDEO_PROCESS_POLL (3s) 时间常量
抽取通用 _click_tab() 方法，新增 _click_video_tab()
新增 _upload_video() — 通过 CDP 的 DOM.setFileInputFiles 上传视频文件
新增 _wait_video_processing() — 轮询等待视频处理完成（最多 120s），期间输出进度
新增 publish_video(title, content, video_path) — 完整视频发布流程
CLI 的 fill / publish 子命令新增 --video 参数（与 --images 互斥）
2. scripts/publish_pipeline.py
新增 --video（本地视频）和 --video-url（视频URL）参数，与图片参数互斥
管道自动区分图文/视频模式，视频模式调用 publisher.publish_video()
3. scripts/image_downloader.py
新增 _guess_video_extension() — 识别 mp4/mov/avi/mkv/flv/wmv/webm
新增 download_video() — 下载视频文件（超时 120s，大块读取 64KB）
4. SKILL.md
描述更新为支持图文+视频
输入判断新增视频优先级
新增「视频发布流程」章节
新增视频发布命令示例（--video 和 --video-url）

二、发布点击事件修复
1. 新增通用方法 _click_element_by_cdp()，先用 JS 获取按钮的 getBoundingClientRect() 坐标，再通过 CDP 的 Input.dispatchMouseEvent 发送真实的 mousePressed + mouseReleased 事件
2. _click_publish() 改用这个方式点击，模拟的是浏览器层面的真实鼠标点击，和用户手动点击效果一致