### PR TITLE
fix: bypass system proxy for local CDP connection (fixes 502 error)

### DIFF
--- a/scripts/cdp_publish.py
+++ b/scripts/cdp_publish.py
@@ -440,7 +440,11 @@ class XiaohongshuPublisher:
         url = f"http://{self.host}:{self.port}/json"
         for attempt in range(2):
             try:
-                resp = requests.get(url, timeout=5)
+                resp = requests.get(
+                    url, 
+                    timeout=5, 
+                    proxies={"http": None, "https": None}
+                )
                 resp.raise_for_status()
                 return resp.json()
             except Exception as e:
@@ -493,6 +497,7 @@ class XiaohongshuPublisher:
         resp = requests.put(
             f"http://{self.host}:{self.port}/json/new?{XHS_CREATOR_URL}",
             timeout=5,
+            proxies={"http": None, "https": None}
         )
         if resp.ok:
             ws_url = resp.json().get("webSocketDebuggerUrl", "")


### PR DESCRIPTION
Description
When running this project in WSL or Linux environments with system-wide proxies enabled, requests to 127.0.0.1:9222 are intercepted, causing a 502 Bad Gateway error and preventing the script from connecting to Chrome.

Changes
Passed proxies={"http": None, "https": None} to requests.get and requests.put inside cdp_publish.py to ensure local traffic goes directly to the Chrome CDP server.