### PR TITLE
perf: optimize search speed (20s → 3.3s)

### DIFF
--- a/scripts/cdp_publish.py
+++ b/scripts/cdp_publish.py
@@ -136,7 +136,7 @@ SELECTORS = {
 }
 
 # Timing
-PAGE_LOAD_WAIT = 3  # seconds to wait after navigation
+PAGE_LOAD_WAIT = 1.5  # seconds to wait after navigation
 TAB_CLICK_WAIT = 2  # seconds to wait after clicking tab
 UPLOAD_WAIT = 6  # seconds to wait after image upload for editor to appear
 VIDEO_PROCESS_TIMEOUT = 120  # seconds to wait for video processing
@@ -880,7 +880,7 @@ class XiaohongshuPublisher:
     def _capture_search_recommendations_via_network(
         self,
         keyword: str,
-        wait_seconds: float = 8.0,
+        wait_seconds: float = 2.5,
         max_suggestions: int = 12,
     ) -> dict[str, Any]:
         """Capture recommend API response from real page traffic."""
@@ -1001,9 +1001,6 @@ class XiaohongshuPublisher:
         if not keyword:
             raise CDPError("Keyword cannot be empty.")
 
-        self._navigate(SEARCH_BASE_URL)
-        self._sleep(2, minimum_seconds=1.0)
-
         explorer = FeedExplorer(
             self._evaluate,
             self._sleep,
@@ -1011,20 +1008,13 @@ class XiaohongshuPublisher:
             click_mouse=self._click_mouse,
         )
 
-        recommendation_result = self._capture_search_recommendations_via_network(keyword=keyword)
-        recommended_keywords = recommendation_result.get("suggestions", [])
-
-        if not recommendation_result.get("ok"):
-            reason = recommendation_result.get("reason") or "recommend_api_failed"
-            print(
-                "[cdp_publish] Warning: failed to capture search recommendations via API. "
-                f"reason={reason}"
-            )
-
-        # Always navigate with keyword URL to keep feed extraction stable.
+        # Navigate directly to search URL with keyword for faster results.
+        # The recommend keyword capture is skipped to avoid ~8-12s overhead.
         search_url = make_search_url(keyword)
         self._navigate(search_url)
-        self._sleep(2, minimum_seconds=1.0)
+        self._sleep(1, minimum_seconds=0.5)
+
+        recommended_keywords: list[str] = []
 
         try:
             feeds = explorer.search_feeds(keyword=keyword, filters=filters)


### PR DESCRIPTION
## Problem

 takes ~20s per call (38s with filters), mostly due to:
1.  adds unnecessary delay after every navigation
2. The recommend keyword capture () waits up to 8s and frequently times out
3.  navigates twice: first to empty search page (to type keyword and capture recommendations), then to the keyword URL

## Changes

1. **: 3s → 1.5s** — 1.5s is sufficient for `__INITIAL_STATE__` to initialize

2. **Recommend API wait: 8s → 2.5s** — most responses arrive within 2s; waiting 8s is wasteful when the API is slow

3. **: skip recommend capture, navigate directly to keyword URL**
   - Removed the double navigation (empty search page → keyword URL)
   - Removed the recommend API capture from the search path
   -  is now always  for 

## Benchmark

| Scenario | Before | After |
|---|---|---|
| search (no filter) | ~20s | **~3.3s** |
| search (with --sort-by/--note-type) | ~38s | **~6.0s** |
| feed detail | ~6s | ~6s (unchanged) |

## Tradeoff

The  field in  response is now always empty. This data was the dropdown suggestions shown while typing — useful for auto-complete UX but not critical for feed search results. If this feature is needed, it can be re-added as a separate method (e.g. `get_search_suggestions`).