### PR TITLE
修复小红书 skill 的全局锁冲突

### DIFF
--- a/scripts/account_manager.py
+++ b/scripts/account_manager.py
@@ -20,9 +20,15 @@ import sys
 import shutil
 from typing import Optional
 
+from run_lock import acquire_locks, build_lock_name
+
 # Config file location
 CONFIG_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "config")
 ACCOUNTS_FILE = os.path.join(CONFIG_DIR, "accounts.json")
+ACCOUNT_CONFIG_LOCK = build_lock_name(
+    "xhs_accounts_config",
+    os.path.abspath(ACCOUNTS_FILE),
+)
 
 # Base directory for account profiles
 PROFILES_BASE = os.path.join(os.environ.get("LOCALAPPDATA", os.path.expanduser("~")),
@@ -254,55 +260,56 @@ def main():
 
     args = parser.parse_args()
 
-    if args.command == "list":
-        accounts = list_accounts()
-        if not accounts:
-            print("No accounts configured.")
-            return
-        print(f"{'Name':<20} {'Alias':<20} {'Default':<10}")
-        print("-" * 50)
-        for acc in accounts:
-            default_mark = "*" if acc["is_default"] else ""
-            print(f"{acc['name']:<20} {acc['alias']:<20} {default_mark:<10}")
+    with acquire_locks(ACCOUNT_CONFIG_LOCK):
+        if args.command == "list":
+            accounts = list_accounts()
+            if not accounts:
+                print("No accounts configured.")
+                return
+            print(f"{'Name':<20} {'Alias':<20} {'Default':<10}")
+            print("-" * 50)
+            for acc in accounts:
+                default_mark = "*" if acc["is_default"] else ""
+                print(f"{acc['name']:<20} {acc['alias']:<20} {default_mark:<10}")
 
-    elif args.command == "add":
-        if add_account(args.name, args.alias):
-            print(f"Account '{args.name}' added.")
-            print(f"Profile dir: {get_profile_dir(args.name)}")
-            print("\nTo log in to this account, run:")
-            print(f"  python cdp_publish.py --account {args.name} login")
-        else:
-            print(f"Error: Account '{args.name}' already exists.", file=sys.stderr)
-            sys.exit(1)
+        elif args.command == "add":
+            if add_account(args.name, args.alias):
+                print(f"Account '{args.name}' added.")
+                print(f"Profile dir: {get_profile_dir(args.name)}")
+                print("\nTo log in to this account, run:")
+                print(f"  python cdp_publish.py --account {args.name} login")
+            else:
+                print(f"Error: Account '{args.name}' already exists.", file=sys.stderr)
+                sys.exit(1)
 
-    elif args.command == "remove":
-        if remove_account(args.name, args.delete_profile):
-            print(f"Account '{args.name}' removed.")
-        else:
-            print(f"Error: Cannot remove account '{args.name}'.", file=sys.stderr)
-            sys.exit(1)
+        elif args.command == "remove":
+            if remove_account(args.name, args.delete_profile):
+                print(f"Account '{args.name}' removed.")
+            else:
+                print(f"Error: Cannot remove account '{args.name}'.", file=sys.stderr)
+                sys.exit(1)
 
-    elif args.command == "info":
-        info = get_account_info(args.name)
-        if info:
-            print(f"Name: {info['name']}")
-            print(f"Alias: {info.get('alias', '')}")
-            print(f"Profile dir: {info.get('profile_dir', '')}")
-            print(f"Default: {'Yes' if info.get('is_default') else 'No'}")
-            print(f"Created: {info.get('created_at', 'Unknown')}")
-        else:
-            print(f"Error: Account '{args.name}' not found.", file=sys.stderr)
-            sys.exit(1)
+        elif args.command == "info":
+            info = get_account_info(args.name)
+            if info:
+                print(f"Name: {info['name']}")
+                print(f"Alias: {info.get('alias', '')}")
+                print(f"Profile dir: {info.get('profile_dir', '')}")
+                print(f"Default: {'Yes' if info.get('is_default') else 'No'}")
+                print(f"Created: {info.get('created_at', 'Unknown')}")
+            else:
+                print(f"Error: Account '{args.name}' not found.", file=sys.stderr)
+                sys.exit(1)
 
-    elif args.command == "set-default":
-        if set_default_account(args.name):
-            print(f"Default account set to '{args.name}'.")
-        else:
-            print(f"Error: Account '{args.name}' not found.", file=sys.stderr)
-            sys.exit(1)
+        elif args.command == "set-default":
+            if set_default_account(args.name):
+                print(f"Default account set to '{args.name}'.")
+            else:
+                print(f"Error: Account '{args.name}' not found.", file=sys.stderr)
+                sys.exit(1)
 
-    elif args.command == "get-profile-dir":
-        print(get_profile_dir(args.account))
+        elif args.command == "get-profile-dir":
+            print(get_profile_dir(args.account))
 
 
 if __name__ == "__main__":

--- a/scripts/cdp_publish.py
+++ b/scripts/cdp_publish.py
@@ -88,7 +88,12 @@ from feed_explorer import (
     make_feed_detail_url,
     make_search_url,
 )
-from run_lock import SingleInstanceError, single_instance
+from run_lock import (
+    SingleInstanceError,
+    acquire_locks,
+    build_lock_name,
+    build_xhs_lock_names,
+)
 
 # ---------------------------------------------------------------------------
 # Configuration - centralised selectors and URLs for easy maintenance
@@ -164,6 +169,10 @@ DEFAULT_LOGIN_CACHE_TTL_HOURS = 12.0
 LOGIN_CACHE_FILE = os.path.abspath(
     os.path.join(SCRIPT_DIR, "..", "tmp", "login_status_cache.json")
 )
+ACCOUNT_CONFIG_LOCK = build_lock_name(
+    "xhs_accounts_config",
+    os.path.abspath(os.path.join(SCRIPT_DIR, "..", "config", "accounts.json")),
+)
 
 
 def _normalize_timing_jitter(value: float) -> float:
@@ -188,6 +197,32 @@ def _resolve_account_name(account_name: str | None) -> str:
     except Exception:
         pass
     return "default"
+
+
+ACCOUNT_MGMT_COMMANDS = {
+    "list-accounts",
+    "add-account",
+    "remove-account",
+    "set-default-account",
+}
+
+
+def _peek_lock_context(argv: list[str]) -> tuple[str, int, str | None, str | None]:
+    """Parse the global CLI context needed to build deterministic locks."""
+    import argparse
+
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--host", default=CDP_HOST)
+    parser.add_argument("--port", type=int, default=CDP_PORT)
+    parser.add_argument("--account")
+    parser.add_argument("--headless", action="store_true")
+    parser.add_argument("--timing-jitter", type=float)
+    parser.add_argument("--reuse-existing-tab", action="store_true")
+    parser.add_argument("--preserve-upload-paths", action="store_true")
+    parser.add_argument("command", nargs="?")
+
+    parsed, _ = parser.parse_known_args(argv)
+    return parsed.host, parsed.port, parsed.account, parsed.command
 
 
 def _build_search_filters_from_args(args) -> SearchFilters | None:
@@ -4739,7 +4774,15 @@ def main():
 
 if __name__ == "__main__":
     try:
-        with single_instance("post_to_xhs_publish"):
+        host, port, account, command = _peek_lock_context(sys.argv[1:])
+        if command in ACCOUNT_MGMT_COMMANDS:
+            with acquire_locks(ACCOUNT_CONFIG_LOCK):
+                main()
+        elif command:
+            resolved_account = _resolve_account_name(account)
+            with acquire_locks(*build_xhs_lock_names(host, port, resolved_account)):
+                main()
+        else:
             main()
     except SingleInstanceError as e:
         print(f"Error: {e}", file=sys.stderr)

--- a/scripts/publish_pipeline.py
+++ b/scripts/publish_pipeline.py
@@ -69,7 +69,7 @@ if SCRIPT_DIR not in sys.path:
 from chrome_launcher import ensure_chrome, restart_chrome
 from cdp_publish import XiaohongshuPublisher, CDPError
 from image_downloader import ImageDownloader
-from run_lock import SingleInstanceError, single_instance
+from run_lock import SingleInstanceError, acquire_locks, build_xhs_lock_names
 
 
 MAX_TIMING_JITTER_RATIO = 0.7
@@ -97,6 +97,34 @@ def _resolve_account_name(account_name: str | None) -> str:
     except Exception:
         pass
     return "default"
+
+
+def _peek_lock_context(argv: list[str]) -> tuple[str, int, str | None]:
+    """Parse the global CLI context needed to build deterministic locks."""
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=9222)
+    parser.add_argument("--account")
+    parser.add_argument("--title")
+    parser.add_argument("--title-file")
+    parser.add_argument("--content")
+    parser.add_argument("--content-file")
+    parser.add_argument("--post-time")
+    parser.add_argument("--image-urls", nargs="+")
+    parser.add_argument("--images", nargs="+")
+    parser.add_argument("--video")
+    parser.add_argument("--video-url")
+    parser.add_argument("--auto-publish", action="store_true")
+    parser.add_argument("--preview", action="store_true")
+    parser.add_argument("--headless", action="store_true")
+    parser.add_argument("--timing-jitter", type=float)
+    parser.add_argument("--reuse-existing-tab", action="store_true")
+    parser.add_argument("--temp-dir")
+    parser.add_argument("--skip-file-check", action="store_true")
+    parser.add_argument("--preserve-upload-paths", action="store_true")
+
+    parsed, _ = parser.parse_known_args(argv)
+    return parsed.host, parsed.port, parsed.account
 
 
 def _jitter_ms(base_ms: int, jitter_ratio: float, minimum_ms: int = 0) -> int:
@@ -622,7 +650,9 @@ def main():
 
 if __name__ == "__main__":
     try:
-        with single_instance("post_to_xhs_publish"):
+        host, port, account = _peek_lock_context(sys.argv[1:])
+        resolved_account = _resolve_account_name(account)
+        with acquire_locks(*build_xhs_lock_names(host, port, resolved_account)):
             main()
     except SingleInstanceError as e:
         print(f"Error: {e}", file=sys.stderr)

--- a/scripts/run_lock.py
+++ b/scripts/run_lock.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import sys
 import tempfile
 import uuid
-from contextlib import contextmanager
+from contextlib import ExitStack, contextmanager
 from datetime import datetime, timezone
 from typing import Any
 
@@ -19,6 +20,30 @@ class SingleInstanceError(RuntimeError):
 def _lock_path(lock_name: str) -> str:
     safe_name = "".join(ch if ch.isalnum() or ch in ("-", "_") else "_" for ch in lock_name)
     return os.path.join(tempfile.gettempdir(), f"{safe_name}.lock")
+
+
+def build_lock_name(prefix: str, *parts: Any) -> str:
+    """Build a short deterministic lock name from arbitrary context parts."""
+    safe_prefix = "".join(ch if ch.isalnum() or ch in ("-", "_") else "_" for ch in prefix)
+    safe_prefix = safe_prefix or "lock"
+    payload = json.dumps(
+        [None if part is None else str(part) for part in parts],
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+    digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
+    return f"{safe_prefix}_{digest}"
+
+
+def build_xhs_lock_names(host: str, port: int, account_name: str) -> tuple[str, str]:
+    """Return the profile and CDP session lock names for a Xiaohongshu run."""
+    normalized_host = host.strip().lower()
+    if normalized_host in {"127.0.0.1", "localhost", "::1"}:
+        normalized_host = "local"
+    normalized_account = account_name.strip() or "default"
+    profile_lock = build_lock_name("xhs_profile", normalized_host, normalized_account)
+    session_lock = build_lock_name("xhs_session", normalized_host, port)
+    return profile_lock, session_lock
 
 
 def _pid_running(pid: int) -> bool:
@@ -122,3 +147,17 @@ def single_instance(lock_name: str = "post_to_xhs_publish"):
             pass
         except OSError:
             pass
+
+
+@contextmanager
+def acquire_locks(*lock_names: str):
+    """Acquire multiple single-instance locks in a deterministic order."""
+    unique_names = [name for name in dict.fromkeys(lock_names) if name]
+    if not unique_names:
+        yield
+        return
+
+    with ExitStack() as stack:
+        for lock_name in sorted(unique_names):
+            stack.enter_context(single_instance(lock_name))
+        yield


### PR DESCRIPTION
﻿## 变更
- 将小红书发布入口的锁从全局 `single_instance` 拆成账号锁 + 会话锁
- 账号管理命令单独加配置锁，避免并发写坏 `accounts.json`
- 更新 skill 说明，提示多 agent 使用不同 `--account` / `--port`

## 原因
上游把 `cdp_publish.py` 和 `publish_pipeline.py` 都包在同一把 `post_to_xhs_publish` 锁里，两个 agent 即使操作不同账号或不同端口，也会被串行化。

## 验证
- `python -m py_compile scripts/run_lock.py scripts/account_manager.py scripts/cdp_publish.py scripts/publish_pipeline.py`

Closes #17
