### PR TITLE
feat: 跨平台支持 macOS / Linux 的 Chrome profile 路径

### DIFF
--- a/scripts/account_manager.py
+++ b/scripts/account_manager.py
@@ -24,9 +24,20 @@ from typing import Optional
 CONFIG_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "config")
 ACCOUNTS_FILE = os.path.join(CONFIG_DIR, "accounts.json")
 
-# Base directory for account profiles
-PROFILES_BASE = os.path.join(os.environ.get("LOCALAPPDATA", os.path.expanduser("~")),
-                              "Google", "Chrome", "XiaohongshuProfiles")
+# Base directory for account profiles (cross-platform)
+def _default_profiles_base() -> str:
+    if sys.platform == "win32":
+        base = os.environ.get("LOCALAPPDATA", os.path.expanduser("~"))
+        return os.path.join(base, "Google", "Chrome", "XiaohongshuProfiles")
+    if sys.platform == "darwin":
+        return os.path.expanduser(
+            "~/Library/Application Support/Google/Chrome/XiaohongshuProfiles"
+        )
+    # Linux / others
+    return os.path.expanduser("~/.config/google-chrome/XiaohongshuProfiles")
+
+
+PROFILES_BASE = _default_profiles_base()
 
 # Default account name (for backward compatibility)
 DEFAULT_PROFILE_NAME = "default"

--- a/scripts/chrome_launcher.py
+++ b/scripts/chrome_launcher.py
@@ -90,11 +90,15 @@ def get_user_data_dir(account: Optional[str] = None) -> str:
         from account_manager import get_profile_dir
         return get_profile_dir(account)
     except ImportError:
-        # Fallback if account_manager not available
-        local_app_data = os.environ.get("LOCALAPPDATA", "")
-        if not local_app_data:
-            local_app_data = os.path.expanduser("~")
-        return os.path.join(local_app_data, "Google", "Chrome", PROFILE_DIR_NAME)
+        # Fallback if account_manager not available (cross-platform)
+        if sys.platform == "win32":
+            base = os.environ.get("LOCALAPPDATA", os.path.expanduser("~"))
+            return os.path.join(base, "Google", "Chrome", PROFILE_DIR_NAME)
+        if sys.platform == "darwin":
+            return os.path.expanduser(
+                f"~/Library/Application Support/Google/Chrome/{PROFILE_DIR_NAME}"
+            )
+        return os.path.expanduser(f"~/.config/google-chrome/{PROFILE_DIR_NAME}")
 
 
 def is_port_open(port: int, host: str = "127.0.0.1") -> bool:


### PR DESCRIPTION
## 背景

`account_manager.PROFILES_BASE` 和 `chrome_launcher.get_user_data_dir` 的 fallback 路径都依赖 Windows 专属环境变量 `LOCALAPPDATA`。在 macOS / Linux 上：
- `LOCALAPPDATA` 不存在 → fallback 到 `~/Google/Chrome/...`
- 这个路径既不规范，也不符合各平台对应用数据目录的约定

## 改动

把两处 PROFILE 基目录改成按平台分发：

| 平台 | 路径 |
|---|---|
| Windows | `%LOCALAPPDATA%\\Google\\Chrome\\XiaohongshuProfiles` (不变) |
| macOS | `~/Library/Application Support/Google/Chrome/XiaohongshuProfiles` |
| Linux | `~/.config/google-chrome/XiaohongshuProfiles` |

`chrome_launcher.get_user_data_dir` 的 ImportError fallback 同步处理。

## 实测

- macOS Darwin 25.3.0 / Python 3.14 / Chrome 148
- 首次运行 `python3 chrome_launcher.py` → Chrome profile 正确落在 `~/Library/Application Support/Google/Chrome/XiaohongshuProfiles/default`
- 扫码登录后再次运行 → 登录态正确复用，无需重新扫码

## 兼容性

- Windows 行为完全不变（同样的 `LOCALAPPDATA` + `Google/Chrome/...` 拼接）
- 老 Windows 用户的现有 profile 目录不会受影响

## 备注

这是 macOS 适配的第一个 PR，后续会单独提一个 `_click_tab` 在首次渲染时找不到 tab 的 polling 修复（独立主题，避免一个 PR 混合关注点）。