### PR TITLE
fix(_click_tab): 等待 creator-tab 渲染完成再点击，避免首次发布报 "Could not find '上传图文' tab"

### DIFF
--- a/scripts/cdp_publish.py
+++ b/scripts/cdp_publish.py
@@ -3492,6 +3492,17 @@ class XiaohongshuPublisher:
         selector_alt_literal = json.dumps(selector_alt)
         tab_text_literal = json.dumps(tab_text)
 
+        # Poll until the tab actually exists in the DOM (React app needs time on first load).
+        tab_selector_literal = json.dumps(tab_selector)
+        tab_ready_deadline = time.time() + 15.0
+        while time.time() < tab_ready_deadline:
+            tab_count = self._evaluate(
+                f"document.querySelectorAll({tab_selector_literal}).length"
+            )
+            if isinstance(tab_count, (int, float)) and tab_count > 0:
+                break
+            time.sleep(0.5)
+
         clicked = self._evaluate(f"""
             (function() {{
                 var targetText = {tab_text_literal};


### PR DESCRIPTION
## 复现

macOS / Chrome 首次启动后，跑：

\`\`\`bash
python3 publish_pipeline.py --preview \\
    --title \"test\" --content \"test\" \\
    --image-urls \"https://picsum.photos/seed/test/1080/1440\"
\`\`\`

报错：

\`\`\`
Error during form fill: Could not find '上传图文' tab.
The page structure may have changed.
\`\`\`

## 根因

跟 DOM 变化无关，**\`.creator-tab\` 选择器是对的**。

\`_click_tab\` 在 \`_navigate(XHS_CREATOR_URL)\` 之后只 sleep ~2 秒就 \`querySelectorAll('div.creator-tab')\`。但小红书发布页是 React 应用，在网络稍慢 / Chrome 首次启动 / macOS 等场景下，\`div.creator-tab\` 要 ~5 秒之后才挂载到 DOM。

实测：手动 navigate 同样的 URL，等 5 秒再查询，可以找到 9 个 \`.creator-tab\` 元素（含\"上传图文\"和\"上传视频\"）。

## 修复

在原 \`querySelectorAll\` 之前加一个轮询，最多等 15 秒直到 \`tab_selector\` 在 DOM 里出现。

\`\`\`python
tab_ready_deadline = time.time() + 15.0
while time.time() < tab_ready_deadline:
    tab_count = self._evaluate(
        f\"document.querySelectorAll({tab_selector_literal}).length\"
    )
    if isinstance(tab_count, (int, float)) and tab_count > 0:
        break
    time.sleep(0.5)
\`\`\`

## 兼容性

- ✅ 向后兼容：tab 已经渲染时第一次循环立即 \`break\`，几乎零开销
- ✅ 失败语义不变：超时后仍走原有的 \"upload input ready\" 兜底 / \`CDPError\` 路径
- ✅ Selector 没改，只加了等待
- ✅ \`_click_image_text_tab\` 和 \`_click_video_tab\` 都受益

## 验证

修复后同一条命令：

\`\`\`
[cdp_publish] Navigating to https://creator.xiaohongshu.com/publish/publish?source=official
[cdp_publish] Clicking '上传图文' tab...
[cdp_publish] Tab '上传图文' clicked, waiting for upload area...
[cdp_publish] Uploading 1 image(s)...
...
FILL_STATUS: READY_TO_PUBLISH
[pipeline] Preview mode is on, skipping publish click.
\`\`\`

整条 publish 链路（navigate → tab click → upload → preview wait → title → content）跑通。

## 环境

- macOS Darwin 25.3.0
- Python 3.14.4
- Chrome 148.0.7778.168
- 仓库 main @ 69a2260

## 备注

与 [#21](https://github.com/white0dew/XiaohongshuSkills/pull/21)（跨平台路径适配）拆开提交，主题独立可分别评审。